### PR TITLE
Mobile resize

### DIFF
--- a/townesquare/src/components/Appbar/index.tsx
+++ b/townesquare/src/components/Appbar/index.tsx
@@ -187,13 +187,16 @@ const HeaderWrapper = styled.div`
 `;
 
 const LogoWrapper = styled(Link)`
-    padding: 16px 48px;
+    padding: 16px 24px;
     display: grid;
     grid-auto-flow: column;
     justify-content: start;
-    svg {
-        
+    svg { 
         text-align: left;
+    }
+
+    @media(min-width: 1024px) {
+        padding: 16px 48px;
     }
 `;
 

--- a/townesquare/src/components/Foundation/Title/index.tsx
+++ b/townesquare/src/components/Foundation/Title/index.tsx
@@ -3,10 +3,11 @@ import React from "react";
 import { TextProps } from "./types";
 
 const getFontSize = ({ fontSize, scale }: TextProps) => {
-    return scale === 'sm' ? "38px"
-        : scale === 'md' ? "75px"
+    return fontSize || 
+        scale === 'sm' ? "36px"
+        : scale === 'md' ? "70px"
         : scale === 'lg' ? '104px' 
-        : fontSize || "75px"
+        : "75px"
   };
 
 const Title = styled.div<TextProps>`

--- a/townesquare/src/components/landing/components/Profile.tsx
+++ b/townesquare/src/components/landing/components/Profile.tsx
@@ -16,15 +16,16 @@ export const Profile = (props) => {
       <ColouredContainer background={theme.colors.bg} >
         <ContentWrapper>
           {isTablet || isMobile ? (
+            <>
+             <Row gap={`${theme.spacing[5]}px`} style={{paddingLeft: isMobile || isTablet ? '0' : `${theme.spacing[6]}px`, zIndex: 1}}>
+             <Title scale="md" textAlign="left">
+               {props.data.Profile ? props.data.Profile.title : 'Loading'}
+             </Title>
+             <Text fontSize="25px">
+               {props.data.Profile ? props.data.Profile.paragraph : 'Loading'}
+             </Text>
+           </Row>
             <Row>
-              <Row gap={`${theme.spacing[5]}px`} style={{paddingLeft: `${theme.spacing[6]}px`, zIndex: 100}}>
-                <Title scale="md" textAlign="left">
-                  {props.data.Profile ? props.data.Profile.title : 'Loading'}
-                </Title>
-                <Text fontSize="25px">
-                  {props.data.Profile ? props.data.Profile.paragraph : 'Loading'}
-                </Text>
-              </Row>
               <Row items="end">
                 <ProfileCardWrapper>
                   <CoverPhotoLandingWrapper className="cover-photo-container">
@@ -33,6 +34,7 @@ export const Profile = (props) => {
                 </ProfileCardWrapper>
               </Row>
             </Row>
+            </>
           ) : (<ProfileCol>
             <ProfileRow gap={`${theme.spacing[5]}px`} style={{paddingLeft: `${theme.spacing[7]}px`, marginTop: `${theme.spacing[7]}px`}}>
               <Title scale="md" textAlign="left" style={{minWidth: '690px'}}>
@@ -71,7 +73,7 @@ const ProfileCol = styled(Col)`
   max-width: 1440px;
   margin: auto;
   > * {
-    z-index: 100;
+    z-index: 1;
   }
     `
 

--- a/townesquare/src/pages/LandingPage/styles.ts
+++ b/townesquare/src/pages/LandingPage/styles.ts
@@ -20,7 +20,7 @@ export const ContentWrapper = styled(Wrapper)`
 `;
 
 export const ColouredContainer = styled(Container)<{background?: string}>`
-  max-width: 100%;
+  max-width: 100vw;
   background: ${props => props.background ?? 'transparent'};
   padding-bottom: 20px;
 `;


### PR DESCRIPTION
- change max-width from 100% to 100vw of `ColouredContainer` in order to fix title/text overflowing on mobile screen
- reduce left side padding of logo wrapper for mobile screen 


![TowneSquare - Google Chrome 8_15_2022 11_20_43 PM](https://user-images.githubusercontent.com/60561405/184791960-cb1358bc-c946-465a-be07-2337311cc941.png)
![TowneSquare - Google Chrome 8_15_2022 11_20_55 PM](https://user-images.githubusercontent.com/60561405/184791962-a22b64f5-ccd7-4b90-b8df-715a02bb4f8c.png)

TODO:

- further testing and adjustment is needed on mobile device in order to prevent page scrolling horizontally.